### PR TITLE
Use :cached feature for app volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ These variables are used building time. If you want to enable/disable after firs
 Docker for Mac has still big problems of slowness with shared volumes (Ref. [docker/for-mac#77](https://github.com/docker/for-mac/issues/77)). In the `docker-compose.yml` file the tool configures the volumes as `cached` (Ref: [docker.com/osxfs-caching/](https://docs.docker.com/docker-for-mac/osxfs-caching/)) to [improve the speed of the framework](https://blog.docker.com/2017/05/user-guided-caching-in-docker-for-mac/).
 
 ```
-- ./app/vendor:/var/www/app/vendor:cached
-- ./app/var/cache:/var/www/app/var/cache:cached
-- ./app/var/logs:/var/www/app/var/logs:cached
+- ./app:/var/www/app:cached
 ```
 
 ### XDebug on Mac

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Out of the box symfony environment using docker-compose. It contains:
 - XDebug (optional)
 - GD libraries (optional)
 
+### Requirements
+
+* Docker >=17.04
+* docker-compose >= 1.8.0
+
 ## Installation
 ### New project
 1. `curl -L https://goo.gl/b5vtmq | bash -s TARGET_DIR`
@@ -40,7 +45,7 @@ These variables are used building time. If you want to enable/disable after firs
 
 ## Docker for Mac
 
-Docker for Mac has still big problems of slowness with shared volumes (Ref. [docker/for-mac#77](https://github.com/docker/for-mac/issues/77)). To fast up your symfony, remove comments in `docker-compose.yml` and use `cached` volumes (Ref: [docker.com/osxfs-caching/](https://docs.docker.com/docker-for-mac/osxfs-caching/))
+Docker for Mac has still big problems of slowness with shared volumes (Ref. [docker/for-mac#77](https://github.com/docker/for-mac/issues/77)). In the `docker-compose.yml` file the tool configures the volumes as `cached` (Ref: [docker.com/osxfs-caching/](https://docs.docker.com/docker-for-mac/osxfs-caching/)) to [improve the speed of the framework](https://blog.docker.com/2017/05/user-guided-caching-in-docker-for-mac/).
 
 ```
 - ./app/vendor:/var/www/app/vendor:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,7 @@ services:
       - mysql:mysqldb
     volumes:
       - ./dockers/php/php.ini:/usr/local/etc/php/php.ini:ro
-      - ./app:/var/www/app
-      - ./app/vendor:/var/www/app/vendor:cached
-      - ./app/var/cache:/var/www/app/var/cache:cached
-      - ./app/var/logs:/var/www/app/var/logs:cached
+      - ./app:/var/www/app:cached
 
   mysql:
     image: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,9 @@ services:
     volumes:
       - ./dockers/php/php.ini:/usr/local/etc/php/php.ini:ro
       - ./app:/var/www/app
-      # Remove comments on Docker for Mac
-      # - ./app/vendor:/var/www/app/vendor:cached
-      # - ./app/var/cache:/var/www/app/var/cache:cached
-      # - ./app/var/logs:/var/www/app/var/logs:cached
+      - ./app/vendor:/var/www/app/vendor:cached
+      - ./app/var/cache:/var/www/app/var/cache:cached
+      - ./app/var/logs:/var/www/app/var/logs:cached
 
   mysql:
     image: mariadb


### PR DESCRIPTION
Using the `:cached` option for volumes performances can improve up to 2.5x times with symfony in docker for mac. ([source](https://blog.docker.com/2017/05/user-guided-caching-in-docker-for-mac/))

Because the `:cached` option is available only since version 17.04 of Docker I've added to the readme a **Requirements** section too.

**Note** this does not affect Docker Linux in any way.