### PR TITLE
Removed remote_log from xdebug.conf due detrimental performance

### DIFF
--- a/dockers/php/Dockerfile
+++ b/dockers/php/Dockerfile
@@ -50,7 +50,6 @@ RUN if [ "$xdebug" -eq "1" ]; then \
             && echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/xdebug.ini \
             && echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/xdebug.ini \
             && echo "xdebug.profiler_enable = 1" >> /usr/local/etc/php/conf.d/xdebug.ini \
-            && echo "xdebug.remote_log='/tmp/xdebug.log'" >> /usr/local/etc/php/conf.d/xdebug.ini \
             && echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/xdebug.ini \
     ;fi
 


### PR DESCRIPTION
Removed `remote_log` config of xdebug which wasn't used. It also caused bad performance.

Ref. https://xdebug.org/docs/all_settings